### PR TITLE
Fix reverse ordering of same name headers

### DIFF
--- a/src/Client/CurlFactory.php
+++ b/src/Client/CurlFactory.php
@@ -101,8 +101,8 @@ class CurlFactory
         $startLine = '';
         $headers = [];
 
-        // Pop lines off until the next empty line or the last line is popped.
-        while ($line = array_pop($lines)) {
+        // Shift lines off until the next empty line or the last line is popped.
+        while ($line = array_shift($lines)) {
             if (substr($line, 0, 5) === 'HTTP/') {
                 $startLine = $line;
             } else {
@@ -113,7 +113,7 @@ class CurlFactory
             }
         }
 
-        return [explode(' ', $startLine, 3), array_reverse($headers)];
+        return [explode(' ', $startLine, 3), $headers];
     }
 
     private static function createErrorResponse(


### PR DESCRIPTION
When received multiple Set-Cookie headers in same response, after parseHeaderOutput the cookies order is reversed. 
Can break in situations where order of cookies is important because later in guzzlehttp/guzzle setCookie is changing the content of the same-name cookie. Therefore instead of eventually ending in cookieJar with the newest cookie value, we are left with the oldest.
This for example has the effect of breaking secure logins in many servers.
