### PR TITLE
debug=false validation added

### DIFF
--- a/src/Client/StreamHandler.php
+++ b/src/Client/StreamHandler.php
@@ -316,6 +316,10 @@ class StreamHandler
 
     private function add_debug(array $request, &$options, $value, &$params)
     {
+        if ($value === false) {
+            return;
+        }
+
         static $map = [
             STREAM_NOTIFY_CONNECT       => 'CONNECT',
             STREAM_NOTIFY_AUTH_REQUIRED => 'AUTH_REQUIRED',


### PR DESCRIPTION
If you call Guzzle client using `debug=false` (having curl disabled) you get printed debug information, since actually right now its just validating that the [key exists](https://github.com/mustela/RingPHP/blob/master/src/Client/StreamHandler.php#L200) but your are not checking the value.
