### PR TITLE
headres from lines function bug fix

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -131,7 +131,7 @@ class Core
 
         foreach ($lines as $line) {
             $parts = explode(':', $line, 2);
-            $headers[trim($parts[0])][] = isset($parts[1])
+            $headers[strtolower(trim($parts[0]))][] = isset($parts[1])
                 ? trim($parts[1])
                 : null;
         }


### PR DESCRIPTION
when headers coming from curl are like this
Set-**c**ookie: a=b
Set-**C**ookie: c=d
then there is a bug, because of associative array of headers
keys of array of headers are case-sensitive