### PR TITLE
Allow listeners to send requests asynchronously

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -134,6 +134,12 @@ class CurlMultiHandler
             } while ($mrc === CURLM_CALL_MULTI_PERFORM);
 
             $this->processMessages();
+            
+            // Start processing any new requests, so they are started immediately in
+            // the next 'curl_multi_select' call.
+            do {
+                $mrc = curl_multi_exec($this->mh, $this->active);
+            } while ($mrc === CURLM_CALL_MULTI_PERFORM);
 
             // If there are delays but no transfers, then sleep for a bit.
             if (!$this->active && $this->delays) {


### PR DESCRIPTION
Currently, the adapter may process any new requests added by listeners one `curl_multi_select` cycle late. For example, a `complete` listener sends a new request (on the line `$this->processMessages();`), which results in `curl_multi_add_handle` being called, but after that the `execute` loop will call `curl_multi_select` waiting for a previous request to be completed before adding the new request to the multi pool via `curl_multi_exec`.

Hope I managed to described the problem well. I know it's only a copy-paste of previous few lines, but I don't have a better idea at the moment. Here at [ManageWP](https://managewp.com/developing-backend-for-managewp-orion) we use our own fork of the `CurlMultiAdapter` for Guzzle 4, but it seems it's much easier for Guzzle 5 to implement this functionality.