### PR TITLE
adding an option for CURL_HTTP_VERSION_2_0

### DIFF
--- a/src/Client/CurlFactory.php
+++ b/src/Client/CurlFactory.php
@@ -180,7 +180,13 @@ class CurlFactory
         ];
 
         if (isset($request['version'])) {
-            $options[CURLOPT_HTTP_VERSION] = $request['version'] == 1.1 ? CURL_HTTP_VERSION_1_1 : CURL_HTTP_VERSION_1_0;
+            if ($request['version'] == 2.0) {
+                $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_2_0;
+            } else if ($request['version'] == 1.1) {
+                $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
+            } else {
+                $options[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_0;
+            }
         }
 
         if (defined('CURLOPT_PROTOCOLS')) {


### PR DESCRIPTION
PHP 5.5 will support `CURL_HTTP_VERSION_2_0` and `CURL_VERSION_HTTP2` ([Request 69278](https://github.com/php/php-src/pull/1192)). You can use `CURL_HTTP_VERSION_2_0` in older versions.

```php
if (!defined('CURL_HTTP_VERSION_2_0')) {
    define('CURL_HTTP_VERSION_2_0', CURL_HTTP_VERSION_1_1 + 1);
}
```