### PR TITLE
The result of CurlFactory::retryFailedRewind should return an array

### DIFF
--- a/src/Client/CurlHandler.php
+++ b/src/Client/CurlHandler.php
@@ -65,16 +65,18 @@ class CurlHandler
     public function __invoke(array $request)
     {
         return new CompletedFutureArray(
-            $this->invokeAsArray($request)
+            $this->_invokeAsArray($request)
         );
     }
 
     /**
+     * @internal
+     *
      * @param array $request
      *
      * @return array
      */
-    public function invokeAsArray(array $request)
+    public function _invokeAsArray(array $request)
     {
         $factory = $this->factory;
 
@@ -91,7 +93,7 @@ class CurlHandler
         $response['transfer_stats'] = array_merge($response['transfer_stats'], $response['curl']);
         $this->releaseEasyHandle($h);
 
-        return CurlFactory::createResponse([$this, 'invokeAsArray'], $request, $response, $hd, $bd);
+        return CurlFactory::createResponse([$this, '_invokeAsArray'], $request, $response, $hd, $bd);
     }
 
     private function checkoutEasyHandle()

--- a/src/Client/CurlHandler.php
+++ b/src/Client/CurlHandler.php
@@ -57,7 +57,24 @@ class CurlHandler
         }
     }
 
+    /**
+     * @param array $request
+     *
+     * @return CompletedFutureArray
+     */
     public function __invoke(array $request)
+    {
+        return new CompletedFutureArray(
+            $this->invokeAsArray($request)
+        );
+    }
+
+    /**
+     * @param array $request
+     *
+     * @return array
+     */
+    public function invokeAsArray(array $request)
     {
         $factory = $this->factory;
 
@@ -74,9 +91,7 @@ class CurlHandler
         $response['transfer_stats'] = array_merge($response['transfer_stats'], $response['curl']);
         $this->releaseEasyHandle($h);
 
-        return new CompletedFutureArray(
-            CurlFactory::createResponse($this, $request, $response, $hd, $bd)
-        );
+        return CurlFactory::createResponse([$this, 'invokeAsArray'], $request, $response, $hd, $bd);
     }
 
     private function checkoutEasyHandle()


### PR DESCRIPTION
When curl has the error status "65" "rewind failed". Which can happen when putting a big file via a resource. Which gets a redirect as response. Then this flow will happen:

We have a curl error
https://github.com/PBWebMedia/RingPHP/blob/master/src/Client/CurlFactory.php#L90
```php
return !empty($response['curl']['errno']) || !isset($response['status'])
            ? self::createErrorResponse($handler, $request, $response)
            : $response;
```


We have error number 65
https://github.com/PBWebMedia/RingPHP/blob/master/src/Client/CurlFactory.php#L112
```php
// Retry when nothing is present or when curl failed to rewind.
        if (!isset($response['err_message'])
            && (empty($response['curl']['errno'])
                || $response['curl']['errno'] == 65)
        ) {
            return self::retryFailedRewind($handler, $request, $response);
        }
```


Nothing of the above happens so we run the handle (gues he follows the redirect)
https://github.com/PBWebMedia/RingPHP/blob/master/src/Client/CurlFactory.php#L544
```php
return $handler($request);
```


But the problem here is that the handle does not return an array but an CompletedFutureArray

Here is the handle set:
https://github.com/guzzle/RingPHP/blob/master/src/Client/CurlHandler.php#L78
```php
return new CompletedFutureArray(
            CurlFactory::createResponse($this, $request, $response, $hd, $bd)
        );
```
As we can see in the row above that will return a CompletedFutureArray

Which it will put in CompletedFutureArray::__construct()
But the constructor accepts an array and not a CompletedFutureArray.

I thought it would be weird to modify CompletedFutureArray so it can also accept itself.
It seemed more clean to make sure that CurlFactory::createResponse always return an array instead having 1 case that returns an object.
