### PR TITLE
[Stream] Fix stream ssl verify

### DIFF
--- a/src/Client/StreamHandler.php
+++ b/src/Client/StreamHandler.php
@@ -284,13 +284,14 @@ class StreamHandler
             }
         } elseif ($value === false) {
             $options['ssl']['verify_peer'] = false;
+            $options['ssl']['allow_self_signed'] = true;
             return;
         } else {
             throw new RingException('Invalid verify request option');
         }
 
         $options['ssl']['verify_peer'] = true;
-        $options['ssl']['allow_self_signed'] = true;
+        $options['ssl']['allow_self_signed'] = false;
     }
 
     private function add_cert(array $request, &$options, $value, &$params)


### PR DESCRIPTION
Hey!

I'm currently implementing SSL verification in egeloen/ivory-http-adapter#62 which test all adapters of guzzle http in order to be sure everything is working fine. When doing it, I discover an inconsitence between Curl (Single/Multi) and the Stream one. Basically, in my test suite I have generated a self signed certificate which allow me to test the feature. For Curl and MultiCurl, if I enable ssl verification, I got an exception because it does not allow self signed cetificate whereas the stream one does not use the same strategy and allow it. This PR rationalizes this behavior.

Feedback welcome!