### PR TITLE
Extract response protocol version

### DIFF
--- a/src/Client/CurlFactory.php
+++ b/src/Client/CurlFactory.php
@@ -80,6 +80,7 @@ class CurlFactory
             $startLine = explode(' ', array_shift($headers), 3);
             $headerList = Core::headersFromLines($headers);
             $response['headers'] = $headerList;
+            $response['version'] = isset($startLine[0]) ? substr($startLine[0], 5) : null;
             $response['status'] = isset($startLine[1]) ? (int) $startLine[1] : null;
             $response['reason'] = isset($startLine[2]) ? $startLine[2] : null;
             $response['body'] = $body;

--- a/src/Client/StreamHandler.php
+++ b/src/Client/StreamHandler.php
@@ -44,6 +44,7 @@ class StreamHandler
         $this->lastHeaders = null;
         $parts = explode(' ', array_shift($hdrs), 3);
         $response = [
+            'version'        => substr($parts[0], 5),
             'status'         => $parts[1],
             'reason'         => isset($parts[2]) ? $parts[2] : null,
             'headers'        => Core::headersFromLines($hdrs),

--- a/tests/Client/CurlFactoryTest.php
+++ b/tests/Client/CurlFactoryTest.php
@@ -611,6 +611,19 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('0', Core::firstHeader($received, 'content-length'));
     }
 
+    public function testParseProtocolVersion()
+    {
+        $res = CurlFactory::createResponse(
+            function () {},
+            [],
+            ['curl' => ['errno' => null]],
+            ['HTTP/1.1 200 Ok'],
+            null
+        );
+
+        $this->assertSame('1.1', $res['version']);
+    }
+
     public function testFailsWhenNoResponseAndNoBody()
     {
         $res = CurlFactory::createResponse(function () {}, [], [], [], null);

--- a/tests/Client/StreamHandlerTest.php
+++ b/tests/Client/StreamHandlerTest.php
@@ -20,6 +20,7 @@ class StreamHandlerTest extends \PHPUnit_Framework_TestCase
             ],
         ]);
 
+        $this->assertEquals('1.1', $response['version']);
         $this->assertEquals(200, $response['status']);
         $this->assertEquals('OK', $response['reason']);
         $this->assertEquals(['Bar'], $response['headers']['Foo']);


### PR DESCRIPTION
Hey!

This PR extracts the response protocol version in order to propagate it in the response. Without this extraction/parsing, the response always get an `1.1` protocol version (default value) even when the response is an `1.0` one.