### PR TITLE
Error descriptions provided also in absence of curl_strerror() function ...

### DIFF
--- a/src/Client/CurlMultiHandler.php
+++ b/src/Client/CurlMultiHandler.php
@@ -232,6 +232,8 @@ class CurlMultiHandler
                 $entry['response']['curl']['errno'] = $done['result'];
                 if (function_exists('curl_strerror')) {
                     $entry['response']['curl']['error'] = curl_strerror($done['result']);
+                } else {
+                    $entry['response']['curl']['error'] = curl_error($done['handle']);
                 }
             }
 


### PR DESCRIPTION
...(PHP version < 5.5)

This little addition allows clear text error descriptions also for PHP 5.4 and earlier. I don't check for the existence of curl_error as it exists along curl_errno since PHP v4.0.3.