### PR TITLE
WIP: Invalid content-length response header with decode_content option

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -281,6 +281,31 @@ class Core
                 && method_exists($message['body'], '__toString'));
     }
 
+
+    /**
+     * Return the body size of the provided message if possible.
+     *
+     * @param array $message Message that contains a 'body' field.
+     *
+     * @return int|null Returns null if is no able to read the size
+     */
+    public static function sizeOfBody($message)
+    {
+        if ($message['body'] instanceof StreamInterface) {
+            return $message['body']->getSize();
+        }
+
+        if (is_resource($message['body'])) {
+            return fstat($message['body'])['size'];
+        }
+
+        if (is_string($message['body'])
+            || (is_object($message['body'])
+                && method_exists($message['body'], '__toString'))) {
+            return strlen((string) $message['body']);
+        }
+    }
+
     /**
      * Debug function used to describe the provided value type and class.
      *

--- a/tests/Client/CurlFactoryTest.php
+++ b/tests/Client/CurlFactoryTest.php
@@ -364,7 +364,10 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
             'client'      => ['decode_content' => true],
         ]);
         $response->wait();
-        $this->assertEquals('test', Core::body($response));
+        $body = Core::body($response);
+        $this->assertEquals('test', $body);
+        $this->assertEquals(strlen($body), Core::header($response, 'Content-Length'));
+        $this->assertNull(Core::header($response, 'Content-Encoding'));
         $this->assertEquals('', $_SERVER['_curl'][CURLOPT_ENCODING]);
         $sent = Server::received()[0];
         $this->assertNull(Core::header($sent, 'Accept-Encoding'));
@@ -386,7 +389,8 @@ class CurlFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('gzip', $_SERVER['_curl'][CURLOPT_ENCODING]);
         $sent = Server::received()[0];
         $this->assertEquals('gzip', Core::header($sent, 'Accept-Encoding'));
-        $this->assertEquals('test', Core::body($response));
+        $this->assertEquals(strlen(Core::body($response)), Core::header($response, 'Content-Length'));
+        $this->assertNull(Core::header($response, 'Content-Encoding'));
     }
 
     public function testDoesNotForceDecode()

--- a/tests/CoreTest.php
+++ b/tests/CoreTest.php
@@ -256,6 +256,28 @@ class CoreTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Core::rewindBody(['body' => new StrClass()]));
     }
 
+    public function testBodySizeOfGuzzleStreams()
+    {
+        $str = Stream::factory('foobar');
+        $this->assertEquals(6, Core::sizeOfBody(['body' => $str]));
+    }
+
+    public function testBodySizeOfStreams()
+    {
+        $str = Stream::factory('foobar')->detach();
+        $this->assertEquals(6, Core::sizeOfBody(['body' => $str]));
+    }
+
+    public function testBodySizeOfStrings()
+    {
+        $this->assertEquals(6, Core::sizeOfBody(['body' => 'foobar']));
+    }
+
+    public function testBodySizeOfToStrings()
+    {
+        $this->assertEquals(3, Core::sizeOfBody(['body' => new StrClass()]));
+    }
+
     public function typeProvider()
     {
         return [


### PR DESCRIPTION
When the `decode_content`option is enabled and the server return an encoded response, the returned
`content-length` and `content-encoding` headers must be fixed.

This problem was already reported and fixed in Guzzle 6+. See https://github.com/guzzle/guzzle/issues/1075
