### PR TITLE
Calling then() on FutureArray or FutureValue returns a new FutureArray or FutureValue, not just a PromiseInterface

### DIFF
--- a/src/Future/BaseFutureTrait.php
+++ b/src/Future/BaseFutureTrait.php
@@ -76,7 +76,7 @@ trait BaseFutureTrait
         callable $onRejected = null,
         callable $onProgress = null
     ) {
-        return $this->wrappedPromise->then($onFulfilled, $onRejected, $onProgress);
+        return new self($this->wrappedPromise->then($onFulfilled, $onRejected, $onProgress), $this->waitfn, $this->cancelfn);
     }
 
     public function cancel()

--- a/tests/Future/FutureArrayTest.php
+++ b/tests/Future/FutureArrayTest.php
@@ -53,4 +53,24 @@ class FutureArrayTest extends \PHPUnit_Framework_TestCase
         $f = new FutureArray($deferred->promise(), function () {});
         $f->foo;
     }
+
+    public function testAfterThenActsLikeFutureArray()
+    {
+        $deferred = new Deferred();
+        $f = new FutureArray(
+            $deferred->promise(),
+            function () use (&$c, $deferred) {
+                $deferred->resolve(['status' => 200]);
+            }
+        );
+        $f = $f->then(function(array $result) {
+            $result['status']++;
+
+            return $result;
+        });
+
+        $this->assertInstanceOf('GuzzleHttp\Ring\Future\FutureArray', $f);
+        $this->assertFalse($this->readAttribute($f, 'isRealized'));
+        $this->assertEquals(201, $f['status']);
+    }
 }

--- a/tests/Future/FutureValueTest.php
+++ b/tests/Future/FutureValueTest.php
@@ -106,4 +106,24 @@ class FutureValueTest extends \PHPUnit_Framework_TestCase
         );
         $f->wait();
     }
+
+    public function testAfterThenActsLikeFutureValue()
+    {
+        $deferred = new Deferred();
+        $f = new FutureValue(
+            $deferred->promise(),
+            function () use ($deferred) {
+                $deferred->resolve(['status' => 200]);
+            }
+        );
+        $f = $f->then(function(array $result) {
+            $result['status']++;
+
+            return $result;
+        });
+
+        $this->assertInstanceOf('GuzzleHttp\Ring\Future\FutureValue', $f);
+        $this->assertFalse($this->readAttribute($f, 'isRealized'));
+        $this->assertEquals(201, $f->wait()['status']);
+    }
 }


### PR DESCRIPTION
When calling `then()` on a `FutureArray` or `FutureValue`, an instance of `FutureInterface` is returned. It would be nice if an instance of `FutureArray` or `FutureValue` would be returned instead.

Typical use case
===
I have a service that communicates with ElasticSearch via their PHP library (that for async calls returns a `FutureArray`) and the service somehow processes the result (the ES response contains lots of stuff I don't need) - that's where the `then()` method comes to play.

I want to use the service output in both a cli command (for one-time testing/debug/...) and a worker that runs completely asynchronously in an event loop. That means in the first case, I would get the result by calling `wait()` and in the second one, I would simply chain another `then()` call to the service output.

Problem
===
Calling `then()` on the `FutureArray` returns a `PromiseInterface` (the result of calling `then()` on the wrapped promise) and I am unable to block until a result is available using the `wait()` method because it simply does not exist in React promises.

Solution
===
The `then()` method can return a new `FutureArray` that simply wraps the result originally returned. 

Considering the `FutureArray` already implements `PromiseInterface`, this should be no BC break.

Instead of `new self(...)` the method could use late static binding and call `new static(...)` but the only difference would be if someone subclassed FutureArray. And in such case, it is quite possible that they created their own constructor with a different signature.

The same applies to `FutureValue`.

I have included two unit tests that test that the `then()` method returns the apprioriate class instance and that the returned value was processed by the callback.